### PR TITLE
feat: ping kafka with kerberos during iterator init

### DIFF
--- a/pkg/broker/kafka/iterator.go
+++ b/pkg/broker/kafka/iterator.go
@@ -230,8 +230,8 @@ func configureIteratorClient(ctx context.Context, config ConsumerConfig, setting
 		return nil, err
 	}
 	// Since client.Ping(ctx) currently (kgo v1.10) doesn't use security authorization it times out
-	// when a security protocol (SASL/Plain or Kerberos) is used and that's why we added a check condition.
-	if config.Kerberos == nil && config.PlainSASL == nil {
+	// when a security protocol (SASL/Plain) is used and that's why we added a check condition.
+	if config.PlainSASL == nil {
 		if err = client.Ping(ctx); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Description
Added client.Ping to Kafka with Kerberos to verify iterator client config. This was already implemented in pkg/broker/kafka/publisher/configurePublisherClient but was omitted here.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (improving code structure without changing external behavior)
- [ ] Other (please explain):

## Checklist
<!-- Ensure all items are complete before submitting your pull request. -->

- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My code is well documented
- [x] I have read and understood the [contribution guidelines](CONTRIBUTING.md)
